### PR TITLE
Use separate ping prefix for pre-pings

### DIFF
--- a/packages/backend/src/routes/api/pings.ts
+++ b/packages/backend/src/routes/api/pings.ts
@@ -90,7 +90,7 @@ export function getRouter(options: {
       const characterName = ctx.session.character.name
       const pingDate = new Date()
       const wrappedText = [
-        '<!channel> PING',
+        `<!channel> ${!ping.scheduledFor ? 'PING' : '### PRE-PING ###'}`,
         '\n\n',
         formattedText,
         '\n\n',


### PR DESCRIPTION
Change the prefix for pre-pings (i.e. when a ping is "scheduled") from `@channel PING` to `@channel ### PRE-PING ###` (while leaving normal pings alone).

I'm not particularly married to the specific text, just used what I see most people using for pre-pings.