### PR TITLE
Discord preping time formatting

### DIFF
--- a/packages/backend/src/routes/api/pings.ts
+++ b/packages/backend/src/routes/api/pings.ts
@@ -66,7 +66,7 @@ export function getRouter(options: {
       throw new Forbidden('you are not permitted to ping using this template')
     }
 
-    const placeholders: { placeholder: string, value: string | (() => string) }[] = [
+    const slackPlaceholders: { placeholder: string, value: string | (() => string) }[] = [
       { placeholder: 'me', value: ctx.session.character?.name ?? '' },
       { placeholder: 'title', value: () => ping.scheduledTitle ?? '' },
       { placeholder: 'time', value: () => {
@@ -80,7 +80,20 @@ export function getRouter(options: {
         )
       } },
     ]
-    const formattedText = placeholders.reduce(
+
+    const discordPlaceholders: { placeholder: string, value: string | (() => string) }[] = [
+      { placeholder: 'me', value: ctx.session.character?.name ?? '' },
+      { placeholder: 'title', value: () => ping.scheduledTitle ?? '' },
+      { placeholder: 'time', value: () => {
+          if (!ping.scheduledFor) {
+            return ''
+          }
+          const timestamp = dayjs.utc(ping.scheduledFor).unix()
+          return `<t:${timestamp}:f> (<t:${timestamp}:R>)`
+        } },
+    ]
+
+    const slackFormattedText = slackPlaceholders.reduce(
       (text, { placeholder, value }) => text.replace(
         new RegExp(`{{${placeholder}}}`, 'igm'),
         () => typeof value === 'function' ? value() : value
@@ -88,12 +101,20 @@ export function getRouter(options: {
       ping.text
     )
 
+    const discordFormattedText = discordPlaceholders.reduce(
+        (text, { placeholder, value }) => text.replace(
+            new RegExp(`{{${placeholder}}}`, 'igm'),
+            () => typeof value === 'function' ? value() : value
+        ),
+        ping.text
+    )
+
     const characterName = ctx.session.character.name
     const pingDate = new Date()
     const wrappedSlackText = [
       `<!channel> ${!ping.scheduledFor ? 'PING' : '### PRE-PING ###'}`,
       '\n\n',
-      formattedText,
+      slackFormattedText,
       '\n\n',
       `> ${dayjs(pingDate).format('YYYY-MM-DD HH:mm:ss')} `,
       `- *${characterName}* to #${template.slackChannelName}`,
@@ -102,7 +123,7 @@ export function getRouter(options: {
     const wrappedDiscordText = [
       `@everyone ${!ping.scheduledFor ? 'PING' : '### PRE-PING ###'}`,
       '\n\n',
-      formattedText,
+      discordFormattedText,
       '\n\n',
       `${dayjs(pingDate).format('YYYY-MM-DD HH:mm:ss')} - ${characterName}`,
     ].join('')

--- a/packages/backend/src/routes/api/pings.ts
+++ b/packages/backend/src/routes/api/pings.ts
@@ -16,7 +16,7 @@ import {
   ApiScheduledPingsResponse,
 } from '@ping-board/common'
 import { UserRoles, userRoles } from '../../middleware/user-roles'
-import { SlackClient, slackLink, SlackRequestFailedError } from '../../slack/slack-client'
+import {SlackClient, SlackRequestFailedError, slackTimestamp} from '../../slack/slack-client'
 import { NeucoreClient } from '../../neucore'
 import { dayjs } from '../../util/dayjs'
 import { PingsRepository, UnknownTemplateError } from '../../database'
@@ -74,10 +74,7 @@ export function getRouter(options: {
           return ''
         }
         const time = dayjs.utc(ping.scheduledFor)
-        return slackLink(
-          `https://time.nakamura-labs.com/#${time.unix()}`,
-          `${time.format('YYYY-MM-DD HH:mm')} (${time.fromNow()})`
-        )
+        return slackTimestamp(time.unix())
       } },
     ]
 
@@ -89,7 +86,8 @@ export function getRouter(options: {
             return ''
           }
           const timestamp = dayjs.utc(ping.scheduledFor).unix()
-          return `<t:${timestamp}:f> (<t:${timestamp}:R>)`
+          // eslint-disable-next-line max-len
+          return `[<t:${timestamp}:f> (<t:${timestamp}:R>)](https://time.nakamura-labs.com/#${timestamp})`
         } },
     ]
 

--- a/packages/backend/src/slack/slack-client.ts
+++ b/packages/backend/src/slack/slack-client.ts
@@ -1,6 +1,7 @@
 import { LogLevel, WebClient } from '@slack/web-api'
 import { Channel } from '@slack/web-api/dist/response/ConversationsListResponse'
 import { InMemoryTTLCache } from '../util/in-memory-ttl-cache'
+import {dayjs} from '../util/dayjs'
 
 export class InvalidChannelIdError extends Error {
   constructor(id: string) {
@@ -97,4 +98,9 @@ export class SlackClient {
 
 export function slackLink(href: string, title: string): string {
   return `<${href.replace(/\|/g, '%7C')}|${title.replace(/>/g, '\\>')}>`
+}
+
+export function slackTimestamp(timestamp: number): string {
+  // eslint-disable-next-line max-len
+  return `<!date^${timestamp}^{date} {time} ({ago})^https://time.nakamura-labs.com/#${timestamp}|${dayjs.utc(timestamp).format('YYYY-MM-DD HH:mm:ss')}>`
 }


### PR DESCRIPTION
When adding discord support i failed to consider the nakamura link that generates, but looks horrible in discord.
<img width="538" height="134" alt="image" src="https://github.com/user-attachments/assets/fad23c70-980e-4be7-a394-a6fc9f2bc9de" />
Replaced it with discord timestamps, that display the time in user's timezone (and a relative one)
<img width="514" height="138" alt="image" src="https://github.com/user-attachments/assets/80040317-72da-40c2-aa15-7e82243a31d1" />
The namakura time link can of course be added back if it's needed

Slack functionality remains unchanged